### PR TITLE
Various changes

### DIFF
--- a/cassandra_mirror/util.py
+++ b/cassandra_mirror/util.py
@@ -5,7 +5,6 @@ from tempfile import NamedTemporaryFile
 from tempfile import TemporaryDirectory
 import os
 
-from cachetools.func import ttl_cache
 import boto3
 import json
 import yaml
@@ -99,12 +98,12 @@ class MovingTemporaryDirectory(TemporaryDirectory):
             pass
 
 
-def compute_top_prefix(config, identity):
+def compute_top_prefix(config):
     prefix = config['s3']['prefix_format'].format(**config['context'])
     return '/'.join((
         prefix,
-        'v1',
-        identity
+        'v2',
+        config['context']['identity']
     ))
 
 def serialize_context(o):

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,0 +1,13 @@
+---
+
+context:
+  cluster: mycluster
+  # identity (optional, default: node uuid queried via JMX)
+
+s3:
+  bucket: mybucket
+  # prefix_format is used with Python string formatting as
+  # prefix_format.format(**context)
+  # Use it to namespace your backups however you desire.
+  prefix_format: 'backups/cassandra/{cluster}'
+

--- a/setup.py
+++ b/setup.py
@@ -3,14 +3,19 @@ from setuptools import setup
 
 setup(
     name='cassandra-mirror',
-    version='0.0.11',
+    version='0.1.1',
     author='Josh Snyder',
-    author_email='josh.snyder@fitbit.com',
+    author_email='josh@code406.com',
     packages=find_packages(),
     entry_points=dict(
-    console_scripts=[
+        console_scripts=[
             'backup=cassandra_mirror.backup:do_backup',
             'restore=cassandra_mirror.restore:do_restore',
         ]
     ),
+    install_requires=[
+        'boto3>=1.4.2',
+        'PyYAML>=3.12',
+        'plumbum>=1.6.3',
+    ],
 )


### PR DESCRIPTION
Primarily:
 * Instead of inferring which columnfamily versions (generations) exist from S3 LIST,
   use a manifest file.
 * Introduce an S3Path object, to make operations on S3 paths easier.
 * Make usage of keypipe an opt-in decision
 * If gof3r is not available, use boto3