### PR TITLE
Add pruning by TTL

### DIFF
--- a/cassandra_mirror/prune.py
+++ b/cassandra_mirror/prune.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+import os
 import sys
 from time import mktime
 from time import time
@@ -19,11 +20,11 @@ logger.setLevel(logging.INFO)
 def to_timestamp(t):
     return mktime(t.timetuple())
 
-def delete_manifests(source, labels_to_keep, grace_after):
+def delete_manifests(source, labels_to_keep, prune_before):
     source = source.with_components('manifests')
 
     trim_length = len(source.key) + 1
-    start_label = reverse_format_nanoseconds(grace_after * 1e9)
+    start_label = reverse_format_nanoseconds(prune_before * 1e9)
     for o in source.descendants(start=start_label):
         if o.key[trim_length:] in labels_to_keep:
             continue
@@ -31,14 +32,11 @@ def delete_manifests(source, labels_to_keep, grace_after):
         logger.info('Deleting %s', o.key)
         o.delete()
 
-def delete_data(source, generations_to_keep, grace_after):
+def delete_data(source, generations_to_keep):
     source = source.with_components('data')
 
     trim_length = len(source.key) + 1
     for o in source.descendants():
-        if to_timestamp(o.last_modified) > grace_after:
-            continue
-
         # Trim the key to remove `source` as a prefix
         trimmed_key = o.key[trim_length:]
         ks, cf, gen, _ = trimmed_key.split('/', 3)
@@ -62,40 +60,31 @@ def verify_labels_is_comprehensive(source, labels_to_keep, grace_after):
         if label not in labels_to_keep:
             raise RuntimeError('List of labels to keep does not cover the grace period')
 
+def prune(source, ttl, marker_dir, label_threshold):
+    label_files = marker_dir.list()
 
-def prune(ttl, labels_to_keep):
-    config = load_config()
+    labels_to_keep = set()
+    label_files_to_delete = []
 
-    grace_after = time() - ttl * 60 * 60
+    prune_before = time() - ttl * 60 * 60
+    for label_file in label_files:
+        if label_file.stat().st_mtime < prune_before:
+            label_files_to_delete.append(label_file)
+        else:
+            labels_to_keep.add(label_file.name)
 
-    source = compute_top_prefix(config)
+    if len(label_files_to_delete) < label_threshold:
+        return
 
-    labels_to_keep = set(labels_to_keep)
     generations_to_keep = set()
-
-
-    verify_labels_is_comprehensive(source, labels_to_keep, grace_after)
 
     for label in labels_to_keep:
         for i in get_generations_referenced_by_manifest(source, label):
             ks, cf, gen, _ = i
             generations_to_keep.add((ks, cf, gen))
 
-    delete_manifests(source, labels_to_keep, grace_after)
-    delete_data(source, generations_to_keep, grace_after)
+    delete_manifests(source, labels_to_keep, prune_before)
+    delete_data(source, generations_to_keep)
 
-def do_prune():
-    parser = argparse.ArgumentParser(
-        description='Prune a cassandra-mirror backup directory of old backups',
-    )
-
-    parser.add_argument('ttl', type=int, help='TTL, in hours')
-    parser.add_argument('label', nargs='+',
-        help='Backup labels to retain'
-    )
-
-    args = parser.parse_args()
-
-    logging.basicConfig(stream=sys.stderr)
-
-    prune(args.ttl, args.label)
+    for label_file in label_files_to_delete:
+        label_file.delete()

--- a/cassandra_mirror/prune.py
+++ b/cassandra_mirror/prune.py
@@ -1,0 +1,101 @@
+import argparse
+import logging
+import sys
+from time import mktime
+from time import time
+
+import boto3
+
+from .restore import get_generations_referenced_by_manifest
+from .util import compute_top_prefix
+from .util import load_config
+from .util import reverse_format_nanoseconds
+
+s3 = boto3.resource('s3')
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+def to_timestamp(t):
+    return mktime(t.timetuple())
+
+def delete_manifests(source, labels_to_keep, grace_after):
+    source = source.with_components('manifests')
+
+    trim_length = len(source.key) + 1
+    start_label = reverse_format_nanoseconds(grace_after * 1e9)
+    for o in source.descendants(start=start_label):
+        if o.key[trim_length:] in labels_to_keep:
+            continue
+
+        logger.info('Deleting %s', o.key)
+        o.delete()
+
+def delete_data(source, generations_to_keep, grace_after):
+    source = source.with_components('data')
+
+    trim_length = len(source.key) + 1
+    for o in source.descendants():
+        if to_timestamp(o.last_modified) > grace_after:
+            continue
+
+        # Trim the key to remove `source` as a prefix
+        trimmed_key = o.key[trim_length:]
+        ks, cf, gen, _ = trimmed_key.split('/', 3)
+        if (ks, cf, gen) in generations_to_keep:
+            continue
+
+        logger.info('Deleting %s', o.key)
+        o.delete()
+
+def verify_labels_is_comprehensive(source, labels_to_keep, grace_after):
+    source = source.with_components('manifests')
+    stop_at = reverse_format_nanoseconds(grace_after * 1e9)
+
+    trim_length = len(source.key) + 1
+    for o in source.descendants():
+        label = o.key[trim_length:]
+        print((label, stop_at))
+        if label > stop_at:
+            break
+
+        if label not in labels_to_keep:
+            raise RuntimeError('List of labels to keep does not cover the grace period')
+
+
+def prune(ttl, labels_to_keep):
+    config = load_config()
+
+    grace_after = time() - ttl * 60 * 60
+
+    source = compute_top_prefix(config)
+
+    labels_to_keep = set(labels_to_keep)
+    generations_to_keep = set()
+
+
+    verify_labels_is_comprehensive(source, labels_to_keep, grace_after)
+
+    for label in labels_to_keep:
+        for i in get_generations_referenced_by_manifest(source, label):
+            ks, cf, gen, _ = i
+            generations_to_keep.add((ks, cf, gen))
+
+    delete_manifests(source, labels_to_keep, grace_after)
+    delete_data(source, generations_to_keep, grace_after)
+
+def do_prune():
+    parser = argparse.ArgumentParser(
+        description='Prune a cassandra-mirror backup directory of old backups',
+    )
+
+    parser.add_argument('ttl', type=int, help='TTL, in hours')
+    parser.add_argument('label', nargs='+',
+        help='Backup labels to retain'
+    )
+
+    args = parser.parse_args()
+
+    logging.basicConfig(stream=sys.stderr)
+
+    prune(args.ttl, args.label)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ setup(
         console_scripts=[
             'backup=cassandra_mirror.backup:do_backup',
             'restore=cassandra_mirror.restore:do_restore',
-            'prune=cassandra_mirror.prune:do_prune',
         ]
     ),
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
         console_scripts=[
             'backup=cassandra_mirror.backup:do_backup',
             'restore=cassandra_mirror.restore:do_restore',
+            'prune=cassandra_mirror.prune:do_prune',
         ]
     ),
     install_requires=[


### PR DESCRIPTION
This entails pretty involved changes to the restoration code paths.

The gist is that the backup module keeps track of which labels it has created, and the pruning module gets rid of any labels which are older than `config['ttl']` hours. It then treats the remaining labels as roots of a DAG, and walks the DAG finding all objects which it should preserve. Then it deletes in objects in S3 which are not in the DAG.

I found the concurrency issues between backup and pruning hard to reason about, so I decided to enforce mutual exclusion between the two processes.